### PR TITLE
Process at-rules (hopefully) correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 
 [![Build Status](https://travis-ci.com/TonyXiang/postcss-themes.svg?branch=master)](https://travis-ci.com/TonyXiang/postcss-themes)
 
+Note about at-rules:
+Except for [Conditional Group At-rules](https://developer.mozilla.org/en-US/docs/Web/CSS/At-rule#conditional_group_rules), others will simply be ignored because of irrelevance. `@keyframes` may contain css varialbe, but it's not feasible to deduce their scope values at build time.
+
 ## Usage
 
 ```bash
@@ -31,7 +34,7 @@ and set this plugin in settings.
 
 ### Input CSS
 ```css
-:root { 
+:root {
   --main-color: green;
 }
 .foo {
@@ -49,14 +52,14 @@ and set this plugin in settings.
 
 ### Output CSS
 ```css
-:root { 
+:root {
   --main-color: green;
 }
 .foo {
   font-size: 16px;
   color: var(--main-color);
 }
-.theme-aaa { 
+.theme-aaa {
   --main-color: red;
 }
 .theme-aaa .foo {

--- a/index.test.js
+++ b/index.test.js
@@ -8,48 +8,162 @@ async function run (input, output, opts) {
   expect(result.warnings()).toHaveLength(0)
 }
 
-const input = `:root { 
+const input = `
+@import url supports( supports-query );
+@font-face {
+  font-family: "Open Sans";
+  src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"),
+       url("/fonts/OpenSans-Regular-webfont.woff") format("woff");
+}
+:root {
   --main-color: green;
 }
+
 .foo {
   font-size: 16px;
   color: var(--main-color);
+}
+.bar {
+  color: #000;
+}
+@keyframes pale {
+  from {
+    color: var(--main-color);
+  }
+
+  to {
+    color: #fff;
+  }
+}
+@media screen and (min-width: 900px) {
+  .article {
+    padding: 1rem 3rem;
+    background-color: var(--main-color);
+  }
+}
+@media screen and (min-width: 600px) {
+  .article {
+    padding: 5rem;
+  }
 }
 `
 
-const output = `:root { 
+const output = `
+@import url supports( supports-query );
+@font-face {
+  font-family: "Open Sans";
+  src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"),
+       url("/fonts/OpenSans-Regular-webfont.woff") format("woff");
+}
+:root {
   --main-color: green;
 }
+
 .foo {
   font-size: 16px;
   color: var(--main-color);
 }
-.theme-aaa { 
+.bar {
+  color: #000;
+}
+@keyframes pale {
+  from {
+    color: var(--main-color);
+  }
+
+  to {
+    color: #fff;
+  }
+}
+@media screen and (min-width: 900px) {
+  .article {
+    padding: 1rem 3rem;
+    background-color: var(--main-color);
+  }
+}
+@media screen and (min-width: 600px) {
+  .article {
+    padding: 5rem;
+  }
+}
+.theme-aaa {
   --main-color: red;
 }
 .theme-aaa .foo {
   color: var(--main-color);
 }
+@media screen and (min-width: 900px) {
+  .theme-aaa .article {
+    background-color: var(--main-color);
+  }
+}
+@media screen and (min-width: 600px) {
+}
 `
 
-const outputMulti = `:root { 
+const outputMulti = `
+@import url supports( supports-query );
+@font-face {
+  font-family: "Open Sans";
+  src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"),
+       url("/fonts/OpenSans-Regular-webfont.woff") format("woff");
+}
+:root {
   --main-color: green;
 }
+
 .foo {
   font-size: 16px;
   color: var(--main-color);
 }
-.theme-aaa { 
+.bar {
+  color: #000;
+}
+@keyframes pale {
+  from {
+    color: var(--main-color);
+  }
+
+  to {
+    color: #fff;
+  }
+}
+@media screen and (min-width: 900px) {
+  .article {
+    padding: 1rem 3rem;
+    background-color: var(--main-color);
+  }
+}
+@media screen and (min-width: 600px) {
+  .article {
+    padding: 5rem;
+  }
+}
+.theme-aaa {
   --main-color: red;
 }
 .theme-aaa .foo {
   color: var(--main-color);
 }
-.theme-bbb { 
+@media screen and (min-width: 900px) {
+  .theme-aaa .article {
+    background-color: var(--main-color);
+  }
+}
+@media screen and (min-width: 600px) {
+}
+.theme-bbb {
   --main-color: blue;
 }
 .theme-bbb .foo {
   color: var(--main-color);
+}
+@media screen and (min-width: 900px) {
+  .theme-bbb .article {
+    background-color: var(--main-color);
+  }
+}
+@media screen and (min-width: 600px) {
 }
 `
 


### PR DESCRIPTION
At-rules without decedent rule nodes should be ignored since they have nothing to do with theme.

For `@keyframes` deducing css variable scope value is not feasible at build time. There's no way to apply theme.

For Conditional Group At-rules, their decedent rules should be handled the same way as general rules. 